### PR TITLE
fix/typings

### DIFF
--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -132,7 +132,8 @@ declare namespace Objection {
     | boolean[]
     | Date[]
     | null
-    | Buffer;
+    | Buffer
+    | Buffer[];
 
   type Expression<T> = T | Raw | ReferenceBuilder | ValueBuilder | AnyQueryBuilder;
 


### PR DESCRIPTION
Fix some typings:
Add Buffer[] as a possible PrimitiveValue which would allow to use array of binary data in queries such as

`this.repository.query().andWhere('id', 'IN', binaryUserIds)`

Add `columnNameToPropertyName` and `propertyNameToColumnName` as they are missing but documented