### PR TITLE
Bump version to 3.1.2-fork2

### DIFF
--- a/doc/release-notes/changelog.md
+++ b/doc/release-notes/changelog.md
@@ -1,4 +1,9 @@
 # Changelog
+## 3.1.2-fork2
+  
+### What's new
+
+- Fix `ref` when referencing JSON fields with MySQL
 
 ## 3.1.2-fork1
   

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objection",
-  "version": "3.1.2-fork1",
+  "version": "3.1.2-fork2",
   "description": "An SQL-friendly ORM for Node.js",
   "main": "lib/objection.js",
   "license": "MIT",


### PR DESCRIPTION
New release incoming
- Fix `ref` when referencing JSON fields with MySQL