### PR TITLE
Bump version 3.1.2-fork3

### DIFF
--- a/doc/release-notes/changelog.md
+++ b/doc/release-notes/changelog.md
@@ -1,4 +1,10 @@
 # Changelog
+## 3.1.2-fork3
+  
+### What's new
+
+- Fix `ref` when referencing JSON sub fields like ```Model.ref(`column:property.field`)```
+
 ## 3.1.2-fork2
   
 ### What's new

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objection",
-  "version": "3.1.2-fork2",
+  "version": "3.1.2-fork3",
   "description": "An SQL-friendly ORM for Node.js",
   "main": "lib/objection.js",
   "license": "MIT",


### PR DESCRIPTION
New release incoming

- Fix `ref` when referencing JSON sub fields like ```Model.ref(`column:property.field`)```
