### PR TITLE
Improve and restrict methods signatures

### DIFF
--- a/tests/ts/examples.ts
+++ b/tests/ts/examples.ts
@@ -511,6 +511,7 @@ qb = qb.distinct('column1', 'column2', 'column3');
 qb = qb.join('tablename', 'column1', '=', 'column2');
 qb = qb.outerJoin('tablename', 'column1', '=', 'column2');
 qb = qb.joinRelated('table');
+qb = qb.joinRelated({ table: true });
 qb = qb.joinRelated('table', { alias: false });
 qb = qb.where(raw('random()', 1, '2'));
 qb = qb.where(raw('random()', 1, '2'), '=', Person.knex().raw('foo'));
@@ -734,6 +735,7 @@ const childrenAndPets: PromiseLike<Person[]> = Person.query()
 
 const childrenAndPets2: PromiseLike<Person[]> = Person.query()
   .withGraphFetched('children')
+  .withGraphFetched({ children: true })
   .where('age', '>=', 42)
   .modifyGraph('[pets, children.pets]', (qb) => qb.orderBy('name'))
   .modifyGraph('[pets, children.pets]', 'orderByName')
@@ -741,6 +743,7 @@ const childrenAndPets2: PromiseLike<Person[]> = Person.query()
 
 const childrenAndPets3: PromiseLike<Person[]> = Person.query()
   .withGraphJoined('children')
+  .withGraphJoined({ children: true })
   .where('age', '>=', 42)
   .modifyGraph('[pets, children.pets]', (qb) => qb.orderBy('name'))
   .modifyGraph('[pets, children.pets]', 'orderByName')
@@ -823,6 +826,7 @@ pagePromise = pageQb.execute();
 
 Person.query()
   .modify('someModifier')
+  .modify(Person.modifiers.myFilter)
   .modify('someModifier', 1, 'foo', { bar: true })
   .modify(['someModifier', 'someOtherModifier'])
   .modify((qb) => qb.where('firstName', 'lol'));

--- a/tests/ts/fixtures/animal.ts
+++ b/tests/ts/fixtures/animal.ts
@@ -28,6 +28,12 @@ export class Animal extends objection.Model {
       onlyDogs(builder: objection.QueryBuilder<Animal>) {
         builder.where('species', 'dog');
       },
+      filterGender(builder: objection.QueryBuilder<Animal>) {
+        // not implemented
+      },
+      filterSpecies(builder: objection.QueryBuilder<Animal>, species: string) {
+        builder.where('species', species);
+      }
     };
   }
 }

--- a/tests/ts/model-class.ts
+++ b/tests/ts/model-class.ts
@@ -15,7 +15,7 @@ import { ModelClass } from '../../';
 
   const tableName: string = modelClass.tableName;
   const persons = await modelClass.query().where('firstName', 'Jennifer');
-  const persons2: Person[] = await modelClass.fetchGraph(persons, 'pets');
+  const persons2: Person[] = await modelClass.fetchGraph(persons, {pets: 'true'});
 })();
 
 (async () => {

--- a/tests/ts/query-builder-api/eager-loading-methods.ts
+++ b/tests/ts/query-builder-api/eager-loading-methods.ts
@@ -32,6 +32,7 @@ import { Animal } from '../fixtures/animal';
   await Person.query().modifiers({
     // You can bind arguments to Model modifiers like this
     filterFemale(builder) {
+      // @ts-expect-error filterGender doesn't accept arguments
       builder.modify(Animal.modifiers.filterGender, 'female');
     },
 

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -170,7 +170,7 @@ declare namespace Objection {
     [key: string]: Modifier<QB>;
   }
 
-  type RelationExpression<M extends Model> = string | object;
+  type RelationExpression<M extends Model> = object;
 
   /**
    * If T is an array, returns the item type, otherwise returns T.
@@ -662,6 +662,10 @@ declare namespace Objection {
 
   interface AllowGraphMethod<QB extends AnyQueryBuilder> {
     (expr: RelationExpression<ModelType<QB>>): QB;
+    /**
+     * @deprecated Use object relation expression instead.
+     */
+    (expr: string): QB;
   }
 
   interface IdentityMethod<QB extends AnyQueryBuilder> {
@@ -821,6 +825,13 @@ declare namespace Objection {
   interface ModifyGraphMethod<QB extends AnyQueryBuilder> {
     <M extends Model>(
       expr: RelationExpression<ModelType<QB>>,
+      modifier: Modifier<QueryBuilderType<M>>,
+    ): QB;
+    /**
+     * @deprecated Use object relation expression instead.
+     */
+    <M extends Model>(
+      expr: string,
       modifier: Modifier<QueryBuilderType<M>>,
     ): QB;
   }
@@ -1086,7 +1097,15 @@ declare namespace Objection {
     for(ids: ForIdValue | ForIdValue[]): this;
 
     withGraphFetched(expr: RelationExpression<M>, options?: GraphOptions): this;
+    /**
+     * @deprecated use the object relation expression instead
+     */ 
+    withGraphFetched(expr: string, options?: GraphOptions): this;
     withGraphJoined(expr: RelationExpression<M>, options?: GraphOptions): this;
+    /**
+     * @deprecated use the object relation expression instead
+     */ 
+    withGraphJoined(expr: string, options?: GraphOptions): this;
 
     truncate(): Promise<void>;
     allowGraph: AllowGraphMethod<this>;
@@ -1504,6 +1523,22 @@ declare namespace Objection {
       expression: RelationExpression<M>,
       options?: FetchGraphOptions,
     ): QueryBuilderType<M>;
+    /**
+     * @deprecated use the object relation expression instead
+     */ 
+    fetchGraph(
+      modelOrObject: PartialModelObject<M>,
+      expression: string,
+      options?: FetchGraphOptions,
+    ): SingleQueryBuilder<QueryBuilderType<M>>;
+    /**
+     * @deprecated use the object relation expression instead
+     */ 
+    fetchGraph(
+      modelOrObject: PartialModelObject<M>[],
+      expression: string,
+      options?: FetchGraphOptions,
+    ): QueryBuilderType<M>;
 
     getRelations(): Relations;
     getRelation(name: string): Relation;
@@ -1619,6 +1654,24 @@ declare namespace Objection {
       expression: RelationExpression<M>,
       options?: FetchGraphOptions,
     ): QueryBuilderType<M>;
+    /**
+     * @deprecated use the object relation expression instead
+     */ 
+    static fetchGraph<M extends Model>(
+      this: Constructor<M>,
+      modelOrObject: PartialModelObject<M>,
+      expression: string,
+      options?: FetchGraphOptions,
+    ): SingleQueryBuilder<QueryBuilderType<M>>;
+    /**
+     * @deprecated use the object relation expression instead
+     */ 
+    static fetchGraph<M extends Model>(
+      this: Constructor<M>,
+      modelOrObject: PartialModelObject<M>[],
+      expression: string,
+      options?: FetchGraphOptions,
+    ): QueryBuilderType<M>;
 
     static getRelations(): Relations;
     static getRelation(name: string): Relation;
@@ -1664,6 +1717,13 @@ declare namespace Objection {
 
     $fetchGraph(
       expression: RelationExpression<this>,
+      options?: FetchGraphOptions,
+    ): SingleQueryBuilder<QueryBuilderType<this>>;
+    /**
+     * @deprecated use the object relation expression instead
+     */ 
+    $fetchGraph(
+      expression: string,
       options?: FetchGraphOptions,
     ): SingleQueryBuilder<QueryBuilderType<this>>;
 

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -160,8 +160,6 @@ declare namespace Objection {
   type ModifierFunction<QB extends AnyQueryBuilder> = (qb: QB, ...args: any[]) => void;
   type Modifier<QB extends AnyQueryBuilder = AnyQueryBuilder> =
     | ModifierFunction<QB>
-    | string
-    | string[]
     | Record<string, Expression<PrimitiveValue>>;
   type OrderByDirection = 'asc' | 'desc' | 'ASC' | 'DESC';
   type OrderByNulls = 'first' | 'last';
@@ -606,6 +604,10 @@ declare namespace Objection {
 
   interface JoinRelatedMethod<QB extends AnyQueryBuilder> {
     (expr: RelationExpression<ModelType<QB>>, opt?: JoinRelatedOptions): QB;
+    /**
+     * @deprecated Use object relation expression instead.
+     */
+    (expr: string, opt?: JoinRelatedOptions): QB;
   }
 
   interface JoinMethod<QB extends AnyQueryBuilder> {
@@ -831,8 +833,21 @@ declare namespace Objection {
      * @deprecated Use object relation expression instead.
      */
     <M extends Model>(
+      expr: RelationExpression<ModelType<QB>>,
+      modifier: string | string[],
+    ): QB;
+    /**
+     * @deprecated Use object relation expression instead.
+     */
+    <M extends Model>(
       expr: string,
       modifier: Modifier<QueryBuilderType<M>>,
+    ): QB;
+    /**
+     * @deprecated Use object relation expression instead.
+     */(
+      expr: string,
+      modifier: string  | string[],
     ): QB;
   }
 
@@ -847,6 +862,10 @@ declare namespace Objection {
 
   interface ModifyMethod<QB extends AnyQueryBuilder> {
     (modifier: Modifier<QB> | Modifier<QB>[], ...args: any[]): QB;
+    /**
+     * @deprecated Use functions / methods instead.
+     */
+    (modifier: string | string[], ...args: any[]): QB;
   }
 
   interface ModifiersMethod<QB extends AnyQueryBuilder> {

--- a/typings/objection/index.d.ts
+++ b/typings/objection/index.d.ts
@@ -861,7 +861,9 @@ declare namespace Objection {
   }
 
   interface ModifyMethod<QB extends AnyQueryBuilder> {
-    (modifier: Modifier<QB> | Modifier<QB>[], ...args: any[]): QB;
+    // TODO: move into a type ?
+    // force the modifier to be compatible with the args passed to it
+    <TArgs extends any>(modifier: ((queryBuilder: QB, ...args: TArgs[]) => void) | ((queryBuilder: QB, ...args: TArgs[]) => void)[], ...args: TArgs[]): QB;
     /**
      * @deprecated Use functions / methods instead.
      */


### PR DESCRIPTION
Avoid using strings instead of methods and properties
Ensure that the args of a modifiers are compatible when passing it as a callback

Here the modifier `filterGender` doesn't take any arg
![image](https://github.com/user-attachments/assets/fd307f57-3be4-49f9-8337-8f6548b57fd0)
You have an error when trying to use it like this
<img width="813" alt="image" src="https://github.com/user-attachments/assets/51bddcee-191f-48a1-b58b-0ac02f9b2a4c">
Screenshot showing the deprecated calls
<img width="730" alt="image" src="https://github.com/user-attachments/assets/6366ddda-5445-4d60-b24b-b226767355b5">
